### PR TITLE
fix(testkit): prefer run:test script if available

### DIFF
--- a/bin/testkit.js
+++ b/bin/testkit.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import fs from 'fs'
+import fs from 'fs/promises'
 import { exec } from 'child_process'
 import { waitForServer } from './wait.js'
 import { spawn } from 'child_process'
@@ -102,8 +102,8 @@ async function run2(args, options) {
   let serverArgs = ['run', 'run']
 
   try {
-    const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'))
-    if (pkg.scripts && pkg.scripts['run:test']) {
+    const pkg = JSON.parse(await fs.readFile('./package.json', 'utf8'))
+    if (pkg?.scripts?.['run:test']) {
       serverArgs = ['run', 'run:test']
     }
   } catch (err) {

--- a/bin/testkit.js
+++ b/bin/testkit.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import fs from 'fs'
 import { exec } from 'child_process'
 import { waitForServer } from './wait.js'
 import { spawn } from 'child_process'
@@ -99,6 +100,16 @@ async function run2(args, options) {
 
   let serverCommand = `npm`
   let serverArgs = ['run', 'run']
+
+  try {
+    const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8'))
+    if (pkg.scripts && pkg.scripts['run:test']) {
+      serverArgs = ['run', 'run:test']
+    }
+  } catch (err) {
+    // ignore
+  }
+
   let serverURL = `http://localhost:${options.port}`
   let secondCommand = `npm`
   let secondArgs = ['run', 'test:run']


### PR DESCRIPTION
Update bin/testkit.js to optionally run the `run:test` script if it is defined in the package.json scripts. This allows running a specific script for testing while falling back to `run` if not specified.

---
*PR created automatically by Jules for task [17457923172864219801](https://jules.google.com/task/17457923172864219801) started by @treeder*